### PR TITLE
fix: remove pkgver() from PKGBUILD to fix AUR version mismatch

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = neoarch-git
 pkgname = neoarch-git
-pkgver = latest
+pkgver = 2.0.0
 pkgrel = 1
 pkgdesc = NeoArch Package Manager for Arch Linux
 url = https://github.com/Sanjaya-Danushka/Neoarch

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -14,11 +14,6 @@ install=neoarch-git.install
 source=('git+https://github.com/Sanjaya-Danushka/Neoarch.git')
 md5sums=('SKIP')
 
-pkgver() {
-  cd Neoarch
-  git describe --long --tags | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
-}
-
 package() {
   cd "$srcdir"
   # Install to /opt/neoarch


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 2.0.0 with simplified versioning mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->